### PR TITLE
Allow configuring DynamoDB host

### DIFF
--- a/lib/orchestrator/configuration.rb
+++ b/lib/orchestrator/configuration.rb
@@ -7,7 +7,8 @@ module Orchestrator
       when :production
         Exercism.config.dynamodb_endpoint
       else
-        "http://localhost:3039"
+        dynamodb_host = ENV.fetch("DYNAMODB_HOST", "localhost")
+        "http://#{dynamodb_host}:3039"
       end
     end
 


### PR DESCRIPTION
We need this to be able to run DynamoDB in a docker-compose environment (see https://github.com/exercism/v3-website/issues/19)