### PR TITLE
Add code to support a background queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'aws-sdk-dynamodb', '~> 1.51'
 gem 'aws-sdk-s3'
 gem 'redis'
 gem 'mandate'
-gem 'exercism-config', '>= 0.79.0'
+gem 'exercism-config', '>= 0.80.0'
 # gem 'exercism-config', path: '../exercism_config'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,8 @@ gem 'aws-sdk-dynamodb', '~> 1.51'
 gem 'aws-sdk-s3'
 gem 'redis'
 gem 'mandate'
-# gem 'exercism-config', '>= 0.76.0'
-gem 'exercism-config', path: '../exercism_config'
+gem 'exercism-config', '>= 0.79.0'
+# gem 'exercism-config', path: '../exercism_config'
 
 group :development, :test do
   gem 'parallel'

--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,8 @@ gem 'aws-sdk-dynamodb', '~> 1.51'
 gem 'aws-sdk-s3'
 gem 'redis'
 gem 'mandate'
-gem 'exercism-config', '>= 0.76.0'
-# gem 'exercism-config', path: '../exercism_config'
+# gem 'exercism-config', '>= 0.76.0'
+gem 'exercism-config', path: '../exercism_config'
 
 group :development, :test do
   gem 'parallel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ../exercism_config
+  specs:
+    exercism-config (0.78.0)
+      aws-sdk-dynamodb (~> 1.0)
+      aws-sdk-secretsmanager (~> 1.0)
+      mandate
+      zeitwerk
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -29,11 +38,6 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    exercism-config (0.76.0)
-      aws-sdk-dynamodb (~> 1.0)
-      aws-sdk-secretsmanager (~> 1.0)
-      mandate
-      zeitwerk
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -62,7 +66,7 @@ GEM
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.2.5)
+    redis (4.5.1)
     regexp_parser (1.7.1)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -119,7 +123,7 @@ DEPENDENCIES
   aws-sdk-dynamodb (~> 1.51)
   aws-sdk-s3
   concurrent-ruby
-  exercism-config (>= 0.76.0)
+  exercism-config!
   mandate
   minitest
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-PATH
-  remote: ../exercism_config
-  specs:
-    exercism-config (0.78.0)
-      aws-sdk-dynamodb (~> 1.0)
-      aws-sdk-secretsmanager (~> 1.0)
-      mandate
-      zeitwerk
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -38,6 +29,11 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    exercism-config (0.79.0)
+      aws-sdk-dynamodb (~> 1.0)
+      aws-sdk-secretsmanager (~> 1.0)
+      mandate
+      zeitwerk
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -123,7 +119,7 @@ DEPENDENCIES
   aws-sdk-dynamodb (~> 1.51)
   aws-sdk-s3
   concurrent-ruby
-  exercism-config!
+  exercism-config (>= 0.79.0)
   mandate
   minitest
   mocha

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    exercism-config (0.79.0)
+    exercism-config (0.80.0)
       aws-sdk-dynamodb (~> 1.0)
       aws-sdk-secretsmanager (~> 1.0)
       mandate
@@ -119,7 +119,7 @@ DEPENDENCIES
   aws-sdk-dynamodb (~> 1.51)
   aws-sdk-s3
   concurrent-ruby
-  exercism-config (>= 0.79.0)
+  exercism-config (>= 0.80.0)
   mandate
   minitest
   mocha

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,11 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+task :process_background_queue do |t|
+  $LOAD_PATH.unshift File.expand_path('./lib', __dir__)
+  require "orchestrator"
+
+  Orchestrator.process_background_queue
+end
+
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task :process_background_queue do |t|
+task :process_background_queue do
   $LOAD_PATH.unshift File.expand_path('./lib', __dir__)
   require "orchestrator"
 

--- a/lib/orchestrator.rb
+++ b/lib/orchestrator.rb
@@ -19,4 +19,8 @@ module Orchestrator
   def self.config
     Configuration.instance
   end
+
+  def self.process_background_queue
+    ProcessBackgroundQueue.()
+  end
 end

--- a/lib/orchestrator/process_background_queue.rb
+++ b/lib/orchestrator/process_background_queue.rb
@@ -35,7 +35,7 @@ module Orchestrator
       return if count < 1
 
       # Note - this isn't in a transaction, so things could potentially get lost here
-      ids = redis.lpop(Exercism::ToolingJob.key_for_queued_in_background, count)
+      ids = redis.lpop(Exercism::ToolingJob.key_for_queued_for_background_processing, count)
       redis.rpush(Exercism::ToolingJob.key_for_queued, ids)
     end
 

--- a/lib/orchestrator/process_background_queue.rb
+++ b/lib/orchestrator/process_background_queue.rb
@@ -1,0 +1,47 @@
+module Orchestrator
+  class ProcessBackgroundQueue
+    include Mandate
+
+    MAX_QUEUE_LENGTH = 10
+
+    def call
+      $stdout.sync = true
+      $stderr.sync = true
+
+      should_exist = false
+      %w[INT TERM].each do |sig|
+        trap sig do
+          puts "Exit signal recieved"
+          should_exist = true
+        end
+      end
+
+      loop do
+        break if should_exist
+
+        sleep(1)
+        execute
+      rescue StandardError => e
+        # If stuff goes wrong should we abort the machine
+        # or should we just give it a shot. Maybe have a counter?
+        puts e
+      end
+    end
+
+    def execute
+      count = MAX_QUEUE_LENGTH - redis.llen(Exercism::ToolingJob.key_for_queued)
+
+      # This can be zero or a negative number
+      return if count < 1
+
+      # Note - this isn't in a transaction, so things could potentially get lost here
+      ids = redis.lpop(Exercism::ToolingJob.key_for_queued_in_background, count)
+      redis.rpush(Exercism::ToolingJob.key_for_queued, ids)
+    end
+
+    memoize
+    def redis
+      Exercism.redis_tooling_client
+    end
+  end
+end

--- a/lib/orchestrator/process_background_queue.rb
+++ b/lib/orchestrator/process_background_queue.rb
@@ -8,16 +8,16 @@ module Orchestrator
       $stdout.sync = true
       $stderr.sync = true
 
-      should_exist = false
+      should_exit = false
       %w[INT TERM].each do |sig|
         trap sig do
           puts "Exit signal recieved"
-          should_exist = true
+          should_exit = true
         end
       end
 
       loop do
-        break if should_exist
+        break if should_exit
 
         sleep(1)
         execute

--- a/lib/orchestrator/retrieve_next_job.rb
+++ b/lib/orchestrator/retrieve_next_job.rb
@@ -7,7 +7,7 @@ module Orchestrator
       locked_key = Exercism::ToolingJob.key_for_locked
 
       job_id = redis.lpop(queued_key)
-      return unless job_id
+      return unless job_id && job_id != ""
 
       begin
         redis.rpush(locked_key, job_id)

--- a/lib/orchestrator/retrieve_next_job.rb
+++ b/lib/orchestrator/retrieve_next_job.rb
@@ -7,7 +7,7 @@ module Orchestrator
       locked_key = Exercism::ToolingJob.key_for_locked
 
       job_id = redis.lpop(queued_key)
-      return unless job_id && job_id != ""
+      return unless job_id && !job_id.empty?
 
       begin
         redis.rpush(locked_key, job_id)

--- a/test/orchestrator/process_background_queue_test.rb
+++ b/test/orchestrator/process_background_queue_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module Orchestrator
+  class ProcessBackgroundQueueTest < Minitest::Test
+    def test_is_fine_with_nothing_in_background_queue
+      cmd = ProcessBackgroundQueue.new
+      cmd.expects(:loop).yields
+      cmd.()
+    end
+
+    def test_moves_up_to_10_things_over
+      15.times do
+        Exercism::ToolingJob.create!(SecureRandom.uuid, :test_runner, :ruby, "two-fer", run_in_background: true)
+      end
+
+      assert_equal 0, redis.llen(Exercism::ToolingJob.key_for_queued)
+      assert_equal 15, redis.llen(Exercism::ToolingJob.key_for_queued_for_background_processing)
+
+      cmd = ProcessBackgroundQueue.new
+      cmd.expects(:loop).yields
+      cmd.()
+
+      assert_equal 10, redis.llen(Exercism::ToolingJob.key_for_queued)
+      assert_equal 5, redis.llen(Exercism::ToolingJob.key_for_queued_for_background_processing)
+    end
+
+    def test_sets_max_queue_size_as_10
+      15.times do
+        Exercism::ToolingJob.create!(SecureRandom.uuid, :test_runner, :ruby, "two-fer", run_in_background: true)
+      end
+      6.times do
+        Exercism::ToolingJob.create!(SecureRandom.uuid, :test_runner, :ruby, "two-fer", run_in_background: false)
+      end
+
+      assert_equal 6, redis.llen(Exercism::ToolingJob.key_for_queued)
+      assert_equal 15, redis.llen(Exercism::ToolingJob.key_for_queued_for_background_processing)
+
+      cmd = ProcessBackgroundQueue.new
+      cmd.expects(:loop).yields
+      cmd.()
+
+      assert_equal 10, redis.llen(Exercism::ToolingJob.key_for_queued)
+      assert_equal 11, redis.llen(Exercism::ToolingJob.key_for_queued_for_background_processing)
+    end
+
+    def redis
+      Exercism.redis_tooling_client
+    end
+  end
+end

--- a/test/orchestrator/retrieve_next_job_test.rb
+++ b/test/orchestrator/retrieve_next_job_test.rb
@@ -17,21 +17,6 @@ module Orchestrator
       assert_equal job_1.id, redis.lindex(Exercism::ToolingJob.key_for_locked, 0)
     end
 
-    def test_background_flow
-      job_1 = Exercism::ToolingJob.create!(SecureRandom.uuid, :test_runner, :ruby, "two-fer")
-      Exercism::ToolingJob.create!(SecureRandom.uuid, :test_runner, :ruby, "two-fer")
-
-      redis = Exercism.redis_tooling_client
-      assert_equal 2, redis.llen(Exercism::ToolingJob.queued_for_background_processing)
-      assert_equal 0, redis.llen(Exercism::ToolingJob.key_for_locked)
-
-      assert_equal job_1, RetrieveNextJob.(background: true)
-      assert_equal 1, redis.llen(Exercism::ToolingJob.queued_for_background_processing)
-      assert_equal 1, redis.llen(Exercism::ToolingJob.key_for_locked)
-
-      assert_equal job_1.id, redis.lindex(Exercism::ToolingJob.key_for_locked, 0)
-    end
-
     def test_no_jobs
       assert_nil RetrieveNextJob.()
     end


### PR DESCRIPTION
This adds a rake task which moves up to 10 jobs onto the end of the queue every second.