### PR TITLE
Remove unused rubocop-rails gem from CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -23,7 +23,6 @@ jobs:
           gem install rubocop -v 0.91.0
           gem install rubocop-minitest
           gem install rubocop-performance
-          gem install rubocop-rails
 
       - name: Run Rubocop
         run: rubocop --except Metrics


### PR DESCRIPTION
This should fix the failing CI
